### PR TITLE
병합때 2배됐던 중복코드 삭제

### DIFF
--- a/src/component/page/History/CancelModal/CancelModal.tsx
+++ b/src/component/page/History/CancelModal/CancelModal.tsx
@@ -2,8 +2,6 @@ import { CancelModalStyled } from "./Styled";
 import { useRecoilState } from "recoil";
 import { modalState } from "../../../../stores/modalState";
 import { useEscapeClose } from "../../../common/CustomHook/CustomHook";
-import { useRecoilState } from "recoil";
-import { modalState } from "../../../../stores/modalState";
 
 interface CancelModalProps {
   appId: number;


### PR DESCRIPTION
CancelModal.tsx의 아래 2줄이 2배됐었음
import { useRecoilState } from "recoil";
import { modalState } from "../../../../stores/modalState";